### PR TITLE
Add datacenters `dev1` & `qa`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let's say you want to simulate an alarm system, create a `alarmSystem.json` file
 #### Final setup
 1. Create a `setup.json` out of the [setup.json.template](setup.json.template) file.
 2. Provide the name of the simulation you want to run (name of the one you created in [simulations](simulations))
-3. Select the AirVantage DataCenter you target: `eu` or `na`
+3. Select the AirVantage DataCenter you target: `eu`, `na`, `qa` or `dev1`
 4. Provide your (or a technical user) credentials on the selected AirVantage DataCenter.
 
 ### Launch the simulation

--- a/config/dev1.json
+++ b/config/dev1.json
@@ -1,0 +1,7 @@
+ {
+     "server": "dev1.airvantage.io",
+     "credentials": {
+         "client_id": "dbc8429b7cdb43a7b5d1dae7fc66d674",
+         "client_secret": "9cc964c11c404f8e9000317321c9be90"
+     }
+ }

--- a/config/qa.json
+++ b/config/qa.json
@@ -1,0 +1,7 @@
+ {
+     "server": "qa.airvantage.io",
+     "credentials": {
+         "client_id": "dbc8429b7cdb43a7b5d1dae7fc66d674",
+         "client_secret": "9cc964c11c404f8e9000317321c9be90"
+     }
+ }


### PR DESCRIPTION
## Changes proposed

Allow to run simulations on `qa` & `dev1`

## Test

```sh
$ vleet
 Launching Vleet simulation
  ✱ Initializing simulation
   ❙ Configuration file "setup.json"
    ➔ Name: mcs
    ➔ Data center: qa  # <= Here it is
    ➔ User: kkinfoo@sierrawireless.com
```